### PR TITLE
BAU-208: Allow distributor(s) to be specified by Id as well as partial name

### DIFF
--- a/Nexar.Supply.Api/ApiV4.cs
+++ b/Nexar.Supply.Api/ApiV4.cs
@@ -53,7 +53,7 @@ namespace Nexar.Supply.Api
 
         private const string NEXAR_BASE_URL = "https://api.nexar.com";
         private const string NEXAR_GRAPHQL = "/graphql";
-        private const string NEXAR_VERSION = "0.5.1";
+        private const string NEXAR_VERSION = "0.5.2";
 
         #endregion
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ From here on, the world is your oyster:
 
 For results that come in a URL format (e.g., for `=NEXAR_SUPPLY_DATASHEET_URL`, `=NEXAR_SUPPLY_DETAIL_URL` or `=NEXAR_SUPPLY_DISTRIBUTOR_URL`, click the "Update Hyperlinks" button to activate the links.
 
+- Top Tip: Some functions allow you to specify the distributor(s).  Here you can either enter a string for a partial match on the name or you cna specify the Seller Id from the [list](https://octopart.com/api/v4/values#sellers) for an exact match.
+
 ## Sample Spreadsheet
 A sample spreadsheet, including examples of functions as well as a small (and unrealistic) Bill-of-Materials (BOM), is provided. 
 * [Sample Excel](samples/NexarSupplytAddInExample.xlsm)


### PR DESCRIPTION
This fix is in support of [ticket 1028](https://support.nexar.com/a/tickets/1028). 

The current pull request makes the following changes:

1. It allows users to specify either a `Seller ID` or a (partially matched) company name in functions which filter distributors.
2. A tip is added to the `README` file.
3. The add-in version is bumped to `v0.5.2`.

@RowMur or @MeEntity: Please can one of you review these code changes?

With these changes, for example, you can specify `2454` instead of `Future Electronics`.  

The particular issue addressed by these changes is a specific case where the user would use `1532` for distributor `TME` because otherwise the partial name matching behaviour means `TME` would match `Utmel`.  

Whilst we could perform an exact match first then a partial match if no exact match is found, that isn't quite right.  It would mean second-guessing what the user wants: with `TME` would they prefer a `Utmel` offer if that's the only one, or is it is better to return offer not found?  This solution avoids that uncertainty: if you specify the company `ID` you are being explicit.